### PR TITLE
Patch to sublime_alignment to allow user to configure how key, separator, varspace, and value are positioned

### DIFF
--- a/Alignment.py
+++ b/Alignment.py
@@ -43,7 +43,9 @@ class AlignmentCommand(sublime_plugin.TextCommand):
         settings = view.settings()
         tab_size = int(settings.get('tab_size', 8))
         use_spaces = settings.get('translate_tabs_to_spaces')
-        add_mid_line_whitespace = settings.get('add_mid_line_whitespace')
+        alignment_format = settings.get('alignment_format')
+        if alignment_format == None:
+            alignment_format = "key-varspace-separator-value"
 
         # This handles aligning single multi-line selections
         if len(sel) == 1:
@@ -173,9 +175,11 @@ class AlignmentCommand(sublime_plugin.TextCommand):
                     length = max_col - normed_rowcol(view, pt)[1]
                     adjustment += length
                     if length >= 0:
-                        if add_mid_line_whitespace:
+                        if alignment_format == "key-varspace-separator-value":
                             view.insert(edit, pt, ' ' * length)
-                        else:
+                        elif alignment_format == "key-separator-varspace-value":
+                            view.insert(edit, pt + 1, ' ' * length)
+                        elif alignment_format == "varspace-key-separator-value":
                             view.insert(edit, textStart, ' ' * length)
                     else:
                         view.erase(edit, sublime.Region(pt + length, pt))

--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -26,9 +26,19 @@
 		"+", "-", "&", "|", "<", ">", "!", "~", "%", "/", "*", "."
 	],
 
-   // This plugin can either align the selected lines by adding spaces
-   // between the "alignment_chars" and the text to the left of it
-   // (mid_line whitespace) or by adding the spaces to the left of the
-   // entire line (which doesn't add whitespace to the middle of the line).
-   "add_mid_line_whitespace": true
+   // This plugin can align the selected lines in a number of ways.
+   //   background-color: black;
+   //   color:            white;
+   // "alignment_format": "key-separator-varspace-value"
+
+   // ... or ...
+   //   background-color: black;
+   //              color: white;
+   // "alignment_format": "varspace-key-separator-value"
+
+   // ... or the default ...
+   //   background-color: black;
+   //   color           : white;
+   "alignment_format": "key-varspace-separator-value"
+
 }

--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -24,5 +24,11 @@
 	// of those must be kept next to the = for the operator to be parsed
 	"alignment_prefix_chars": [
 		"+", "-", "&", "|", "<", ">", "!", "~", "%", "/", "*", "."
-	]
+	],
+
+   // This plugin can either align the selected lines by adding spaces
+   // between the "alignment_chars" and the text to the left of it
+   // (mid_line whitespace) or by adding the spaces to the left of the
+   // entire line (which doesn't add whitespace to the middle of the line).
+   "add_mid_line_whitespace": true
 }

--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -26,19 +26,19 @@
 		"+", "-", "&", "|", "<", ">", "!", "~", "%", "/", "*", "."
 	],
 
-   // This plugin can align the selected lines in a number of ways.
-   //   background-color: black;
-   //   color:            white;
-   // "alignment_format": "key-separator-varspace-value"
+	// This plugin can align the selected lines in a number of ways.
+	//   background-color: black;
+	//   color:            white;
+	// "alignment_format": "key-separator-varspace-value"
 
-   // ... or ...
-   //   background-color: black;
-   //              color: white;
-   // "alignment_format": "varspace-key-separator-value"
+	// ... or ...
+	//   background-color: black;
+	//              color: white;
+	// "alignment_format": "varspace-key-separator-value"
 
-   // ... or the default ...
-   //   background-color: black;
-   //   color           : white;
-   "alignment_format": "key-varspace-separator-value"
+	// ... or the default ...
+	//   background-color: black;
+	//   color           : white;
+	"alignment_format": "key-varspace-separator-value"
 
 }


### PR DESCRIPTION
This change satisfies my need that I requested at https://github.com/wbond/sublime_alignment/issues/37 and also adds the functionality that was requested at https://github.com/wbond/sublime_alignment/issues/27

Namely, it adds a new config option called alignment_format to allow for the following possible alignment configurations:

``` json
   //   background-color: black;
   //   color:            white;
   // "alignment_format": "key-separator-varspace-value"

   // ... or ...
   //   background-color: black;
   //              color: white;
   // "alignment_format": "varspace-key-separator-value"

   // ... or the default ...
   //   background-color: black;
   //   color           : white;
   "alignment_format": "key-varspace-separator-value"
```

Thanks!
