### PR TITLE
Make it so that when no region is selected, align the entire file

### DIFF
--- a/Alignment.py
+++ b/Alignment.py
@@ -85,6 +85,8 @@ class AlignmentCommand(sublime_plugin.TextCommand):
         use_spaces = settings.get('translate_tabs_to_spaces')
 
         def align_lines(line_nums):
+            points = []
+            max_col = 0
             trim_trailing_white_space = \
                 settings.get('trim_trailing_white_space_on_save')
 

--- a/Alignment.py
+++ b/Alignment.py
@@ -208,17 +208,6 @@ class AlignmentCommand(sublime_plugin.TextCommand):
                         adjustment += convert_to_mid_line_tabs(view, edit,
                                                                tab_size, pt, length)
 
-        # # This handles aligning single multi-line selections
-        # print len(sel)
-        # for line in view.lines(sel[0]):
-        #     print '%d\n' % view.rowcol(line.a)[0]
-
-        # if len(sel) == 0:
-        #     region = sublime.Region(0, view.size())
-        #     code = view.substr(region)
-        #     for line_nums in get_blocks(code):
-        #         align_lines(line_nums)
-
         if len(sel) == 1:
             if len(view.lines(sel[0])) == 1:
                 region = sublime.Region(0, view.size())

--- a/Alignment.sublime-commands
+++ b/Alignment.sublime-commands
@@ -1,0 +1,3 @@
+[
+    { "caption": "Alignment: Align selected region or whole file", "command": "alignment" }
+]


### PR DESCRIPTION
I made it so that, If a user has not selected any region, the plugin will align the whole file block-by-block.  You might want to see it in action; it's really cool.

For example, this block of code:

```
1 + 1 = 2
2 = 3
  wadw = 21
  awd = 2121
```

will be formatted to:

```
1 + 1 = 2
2     = 3
  wadw = 21
  awd  = 2121
```

I also added a command to the palette.
