### PR TITLE
Fix cmd-control-a keybinding in OSX

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,3 @@
 [
-	{ "keys": ["super+ctrl+a"], "command": "alignment" }
+	{ "keys": ["command+ctrl+a"], "command": "alignment" }
 ]


### PR DESCRIPTION
The super-ctrl-a keybinding did not work properly - this one does.
