### PR TITLE
Added ":" to ruby files for hash alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.sublime-project
 *.sublime-workspace
+.DS_Store

--- a/RB.sublime-settings
+++ b/RB.sublime-settings
@@ -1,0 +1,3 @@
+{
+	"alignment_chars": ["=", ":"]
+}


### PR DESCRIPTION
To support the "new" hash sign in ruby 1.9.
Works:
{ :some_key => some_value }

Doesn't work:
{ some_key: some_value }

This PR fixes it.